### PR TITLE
setPixels stride

### DIFF
--- a/app/src/main/java/com/showlin/simpleQRCode/Utility.kt
+++ b/app/src/main/java/com/showlin/simpleQRCode/Utility.kt
@@ -64,7 +64,7 @@ object Utility {
             }
         }
         val bitmap = Bitmap.createBitmap(bitMatrixWidth, bitMatrixHeight, Bitmap.Config.ARGB_4444)
-        bitmap.setPixels(pixels, 0, 500, 0, 0, bitMatrixWidth, bitMatrixHeight)
+        bitmap.setPixels(pixels, 0, bitMatrixWidth, 0, 0, bitMatrixWidth, bitMatrixHeight)
 
         return bitmap
     }


### PR DESCRIPTION
Generated `BitMatrix` may add padding, increasing `width`.
`stride` must be greater or equal to `width`.
[journeyapps/zxing-android-embedded](https://github.com/journeyapps/zxing-android-embedded/blob/d09b7c76c3124fbfbd096a65d60b1997f37ff90f/zxing-android-embedded/src/com/journeyapps/barcodescanner/BarcodeEncoder.java#L49)